### PR TITLE
fix!: switch to use basis points instead of integer percents

### DIFF
--- a/__test__/paras.ava.ts
+++ b/__test__/paras.ava.ts
@@ -5,11 +5,11 @@ import { nftTokensForOwner, mint, BalanceDelta, deploy, totalCost } from "./util
 function getRoyalties({ root, alice, eve }) {
   return {
     accounts: {
-      [root.accountId]: 10,
-      [alice.accountId]: 20,
-      [eve.accountId]: 70,
+      [root.accountId]: 1_000,
+      [alice.accountId]: 2_000,
+      [eve.accountId]: 7_000,
     },
-    percent: 20,
+    percent: 2_000,
   };
 }
 
@@ -105,7 +105,8 @@ runner.test("buy one", async (t, { root, tenk, paras, bob, eve }) => {
       attachedDeposit: ONE_NEAR,
     }
   );
-
+  
+  await bob2Delta.log();
   await bob2Delta.isLessOrEqual(ONE_NEAR.neg());
   await bobDelta.isGreaterOrEqual(NEAR.parse("750 mN"));
 

--- a/__test__/royalties.ava.ts
+++ b/__test__/royalties.ava.ts
@@ -6,12 +6,12 @@ if (Workspace.networkIsSandbox()) {
   function createRoyalties({ root, alice, bob, eve }) {
     return {
       accounts: {
-        [root.accountId]: 10,
-        [alice.accountId]: 10,
-        [bob.accountId]: 10,
-        [eve.accountId]: 70,
+        [root.accountId]: 1_000,
+        [alice.accountId]: 1_000,
+        [bob.accountId]: 1_000,
+        [eve.accountId]: 7_000,
       },
-      percent: 20,
+      percent: 2_000,
     };
   }
 
@@ -44,11 +44,17 @@ if (Workspace.networkIsSandbox()) {
       balance,
       max_len_payout: 10,
     });
+    t.log(payouts)
+    t.log((await tenk.view_raw("nft_payout", {
+      token_id,
+      balance,
+      max_len_payout: 10,
+    })).logs);
     let innerPayout = createRoyalties({ root, bob, alice, eve }).accounts;
     t.log(innerPayout);
     Object.keys(innerPayout).map(
       (key) =>
-        (innerPayout[key] = NEAR.parse(`${innerPayout[key]}N`).toString())
+        (innerPayout[key] = NEAR.parse(`${innerPayout[key]}cN`).toString())
     );
     innerPayout[root.accountId] = balance
       .mul(NEAR.from(4))


### PR DESCRIPTION
Instead of `1-100` the percents are represented as basis points, 1-10,000.  This allows for more accurate splits.