### PR TITLE
feat: auto-submit when no required args

### DIFF
--- a/gui/src/near/methods.ts
+++ b/gui/src/near/methods.ts
@@ -43,3 +43,32 @@ export function getMethod(m?: string | null): Schema | undefined {
   if (!hasContractMethod(m as MethodName)) return undefined
   return methods[m as MethodName]
 }
+
+type MethodDefinition = {
+  additionalProperties?: boolean
+  contractMethod?: "view" | "change"
+  properties?: {
+    args: {
+      additionalProperties: boolean
+      properties: Record<string, JSONSchema7>
+      required?: string[]
+      type?: string
+    }
+    options?: {
+      additionalProperties: boolean
+      properties: Record<string, JSONSchema7>
+      required?: string[]
+      type?: string
+    }
+  },
+  required?: string[]
+  type?: string
+}
+
+export function getDefinition(m?: string): MethodDefinition | undefined {
+  if (!m) return undefined
+  const def = topLevelSchema.definitions[m as MethodName]
+  if (!def) return undefined
+  if (!hasContractMethodProperty(def)) return undefined
+  return def as MethodDefinition
+}


### PR DESCRIPTION
This moves `onSubmit` to a memoized function that only gets redefined if dependencies change, then automatically calls it if the chosen method has no required args.

![Gifable-2022-03-24T14:15:39](https://user-images.githubusercontent.com/221614/159983865-9a18b63d-00b5-432c-bdc5-d117b590d5b4.gif)
