### PR TITLE
feat: highlight owner methods

### DIFF
--- a/contracts/tenk/dist/index.d.ts
+++ b/contracts/tenk/dist/index.d.ts
@@ -222,154 +222,167 @@ export declare class Contract {
         public_key: PublicKey;
     }, options?: ChangeMethodOptions): transactions.Action;
     /**
-    * Allows given public key to claim sent balance.
-    * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-    * Claim tokens for specific account that are attached to the public key this tx is signed with.
-    */
-    claim(args: {
-        account_id: AccountId;
-    }, options?: ChangeMethodOptions): Promise<void>;
-    /**
-    * Allows given public key to claim sent balance.
-    * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-    * Claim tokens for specific account that are attached to the public key this tx is signed with.
-    */
-    claimRaw(args: {
-        account_id: AccountId;
-    }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
-    /**
-    * Allows given public key to claim sent balance.
-    * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-    * Claim tokens for specific account that are attached to the public key this tx is signed with.
-    */
-    claimTx(args: {
-        account_id: AccountId;
-    }, options?: ChangeMethodOptions): transactions.Action;
-    /**
-    * Create new account and and claim tokens to it.
-    */
-    create_account_and_claim(args: {
-        new_account_id: AccountId;
-        new_public_key: PublicKey;
-    }, options?: ChangeMethodOptions): Promise<void>;
-    /**
-    * Create new account and and claim tokens to it.
-    */
-    create_account_and_claimRaw(args: {
-        new_account_id: AccountId;
-        new_public_key: PublicKey;
-    }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
-    /**
-    * Create new account and and claim tokens to it.
-    */
-    create_account_and_claimTx(args: {
-        new_account_id: AccountId;
-        new_public_key: PublicKey;
-    }, options?: ChangeMethodOptions): transactions.Action;
-    /**
     * Returns the balance associated with given key.
     */
     get_key_balance(args?: {}, options?: ViewFunctionOptions): Promise<U128>;
     check_key(args: {
         public_key: PublicKey;
     }, options?: ViewFunctionOptions): Promise<boolean>;
-    on_create_and_claim(args: {
-        mint_for_free: boolean;
-    }, options?: ChangeMethodOptions): Promise<void>;
-    on_create_and_claimRaw(args: {
-        mint_for_free: boolean;
-    }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
-    on_create_and_claimTx(args: {
-        mint_for_free: boolean;
-    }, options?: ChangeMethodOptions): transactions.Action;
     get_linkdrop_contract(args?: {}, options?: ViewFunctionOptions): Promise<AccountId>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     transfer_ownership(args: {
         new_owner: AccountId;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     transfer_ownershipRaw(args: {
         new_owner: AccountId;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     transfer_ownershipTx(args: {
         new_owner: AccountId;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_initial_royalties(args: {
         initial_royalties: Royalties;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_initial_royaltiesRaw(args: {
         initial_royalties: Royalties;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_initial_royaltiesTx(args: {
         initial_royalties: Royalties;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_royalties(args: {
         royalties: Royalties;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_royaltiesRaw(args: {
         royalties: Royalties;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_royaltiesTx(args: {
         royalties: Royalties;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_allowance(args: {
         allowance: u32;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_allowanceRaw(args: {
         allowance: u32;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_allowanceTx(args: {
         allowance: u32;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_uri(args: {
         uri: string;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_uriRaw(args: {
         uri: string;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_uriTx(args: {
         uri: string;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     add_whitelist_accounts(args: {
         accounts: AccountId[];
         allowance?: u32;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     add_whitelist_accountsRaw(args: {
         accounts: AccountId[];
         allowance?: u32;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     add_whitelist_accountsTx(args: {
         accounts: AccountId[];
         allowance?: u32;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_whitelist_accounts(args: {
         accounts: AccountId[];
         allowance_increase: u32;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_whitelist_accountsRaw(args: {
         accounts: AccountId[];
         allowance_increase: u32;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     update_whitelist_accountsTx(args: {
         accounts: AccountId[];
         allowance_increase: u32;
     }, options?: ChangeMethodOptions): transactions.Action;
     /**
-    * Contract wwill
+    * End public sale/minting, going back to the pre-presale state in which no one can mint.
+    * @allow ["::admins", "::owner"]
     */
-    close_contract(args?: {}, options?: ChangeMethodOptions): Promise<boolean>;
+    close_sale(args?: {}, options?: ChangeMethodOptions): Promise<boolean>;
     /**
-    * Contract wwill
+    * End public sale/minting, going back to the pre-presale state in which no one can mint.
+    * @allow ["::admins", "::owner"]
     */
-    close_contractRaw(args?: {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    close_saleRaw(args?: {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
     /**
-    * Contract wwill
+    * End public sale/minting, going back to the pre-presale state in which no one can mint.
+    * @allow ["::admins", "::owner"]
     */
-    close_contractTx(args?: {}, options?: ChangeMethodOptions): transactions.Action;
+    close_saleTx(args?: {}, options?: ChangeMethodOptions): transactions.Action;
     /**
     * Override the current presale start time to start presale now.
     * Most provide when public sale starts. None, means never.
     * Can provide new presale price.
     * Note: you most likely won't need to call this since the presale
     * starts automatically based on time.
+    * @allow ["::admins", "::owner"]
     */
     start_presale(args: {
         public_sale_start?: TimestampMs;
@@ -381,6 +394,7 @@ export declare class Contract {
     * Can provide new presale price.
     * Note: you most likely won't need to call this since the presale
     * starts automatically based on time.
+    * @allow ["::admins", "::owner"]
     */
     start_presaleRaw(args: {
         public_sale_start?: TimestampMs;
@@ -392,34 +406,47 @@ export declare class Contract {
     * Can provide new presale price.
     * Note: you most likely won't need to call this since the presale
     * starts automatically based on time.
+    * @allow ["::admins", "::owner"]
     */
     start_presaleTx(args: {
         public_sale_start?: TimestampMs;
         presale_price?: U128;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     start_sale(args: {
         price?: YoctoNear;
     }, options?: ChangeMethodOptions): Promise<boolean>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     start_saleRaw(args: {
         price?: YoctoNear;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     start_saleTx(args: {
         price?: YoctoNear;
     }, options?: ChangeMethodOptions): transactions.Action;
     /**
     * Add a new admin. Careful who you add!
+    * @allow ["::admins", "::owner"]
     */
     add_admin(args: {
         account_id: AccountId;
     }, options?: ChangeMethodOptions): Promise<boolean>;
     /**
     * Add a new admin. Careful who you add!
+    * @allow ["::admins", "::owner"]
     */
     add_adminRaw(args: {
         account_id: AccountId;
     }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
     /**
     * Add a new admin. Careful who you add!
+    * @allow ["::admins", "::owner"]
     */
     add_adminTx(args: {
         account_id: AccountId;
@@ -427,6 +454,7 @@ export declare class Contract {
     /**
     * Update public sale price.
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     update_price(args: {
         price: U128;
@@ -434,6 +462,7 @@ export declare class Contract {
     /**
     * Update public sale price.
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     update_priceRaw(args: {
         price: U128;
@@ -441,6 +470,7 @@ export declare class Contract {
     /**
     * Update public sale price.
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     update_priceTx(args: {
         price: U128;
@@ -448,6 +478,7 @@ export declare class Contract {
     /**
     * Update the presale price
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     update_presale_price(args: {
         presale_price?: U128;
@@ -455,6 +486,7 @@ export declare class Contract {
     /**
     * Update the presale price
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     update_presale_priceRaw(args: {
         presale_price?: U128;
@@ -462,10 +494,19 @@ export declare class Contract {
     /**
     * Update the presale price
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     update_presale_priceTx(args: {
         presale_price?: U128;
     }, options?: ChangeMethodOptions): transactions.Action;
+    /**
+    * Current contract owner
+    */
+    owner(args?: {}, options?: ViewFunctionOptions): Promise<AccountId>;
+    /**
+    * Current set of admins
+    */
+    admins(args?: {}, options?: ViewFunctionOptions): Promise<AccountId[]>;
     /**
     * Check whether an account is allowed to mint during the presale
     */
@@ -524,10 +565,6 @@ export declare class Contract {
     * Initial size of collection. Number left to raffle + current total supply
     */
     initial(args?: {}, options?: ViewFunctionOptions): Promise<u64>;
-    /**
-    * Current set of admins
-    */
-    admins(args?: {}, options?: ViewFunctionOptions): Promise<AccountId[]>;
     new_default_meta(args: {
         owner_id: AccountId;
         metadata: InitialMetadata;
@@ -591,21 +628,6 @@ export declare class Contract {
     nft_mint_manyTx(args: {
         num: u32;
     }, options?: ChangeMethodOptions): transactions.Action;
-    on_send_with_callback(args?: {}, options?: ChangeMethodOptions): Promise<void>;
-    on_send_with_callbackRaw(args?: {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
-    on_send_with_callbackTx(args?: {}, options?: ChangeMethodOptions): transactions.Action;
-    link_callback(args: {
-        account_id: AccountId;
-        mint_for_free: boolean;
-    }, options?: ChangeMethodOptions): Promise<Token>;
-    link_callbackRaw(args: {
-        account_id: AccountId;
-        mint_for_free: boolean;
-    }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome>;
-    link_callbackTx(args: {
-        account_id: AccountId;
-        mint_for_free: boolean;
-    }, options?: ChangeMethodOptions): transactions.Action;
 }
 /**
 * Create a pending token that can be claimed with corresponding private key
@@ -630,53 +652,6 @@ export interface CreateLinkdrop {
 }
 export declare type CreateLinkdrop__Result = void;
 /**
-* Allows given public key to claim sent balance.
-* Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-* Claim tokens for specific account that are attached to the public key this tx is signed with.
-*
-* @contractMethod change
-*/
-export interface Claim {
-    args: {
-        account_id: AccountId;
-    };
-    options: {
-        /** Units in gas
-        * @pattern [0-9]+
-        * @default "30000000000000"
-        */
-        gas?: string;
-        /** Units in yoctoNear
-        * @default "0"
-        */
-        attachedDeposit?: Balance;
-    };
-}
-export declare type Claim__Result = void;
-/**
-* Create new account and and claim tokens to it.
-*
-* @contractMethod change
-*/
-export interface CreateAccountAndClaim {
-    args: {
-        new_account_id: AccountId;
-        new_public_key: PublicKey;
-    };
-    options: {
-        /** Units in gas
-        * @pattern [0-9]+
-        * @default "30000000000000"
-        */
-        gas?: string;
-        /** Units in yoctoNear
-        * @default "0"
-        */
-        attachedDeposit?: Balance;
-    };
-}
-export declare type CreateAccountAndClaim__Result = void;
-/**
 * Returns the balance associated with given key.
 *
 * @contractMethod view
@@ -697,27 +672,6 @@ export interface CheckKey {
 export declare type CheckKey__Result = boolean;
 /**
 *
-* @contractMethod change
-*/
-export interface OnCreateAndClaim {
-    args: {
-        mint_for_free: boolean;
-    };
-    options: {
-        /** Units in gas
-        * @pattern [0-9]+
-        * @default "30000000000000"
-        */
-        gas?: string;
-        /** Units in yoctoNear
-        * @default "0"
-        */
-        attachedDeposit?: Balance;
-    };
-}
-export declare type OnCreateAndClaim__Result = void;
-/**
-*
 * @contractMethod view
 */
 export interface GetLinkdropContract {
@@ -725,6 +679,7 @@ export interface GetLinkdropContract {
 }
 export declare type GetLinkdropContract__Result = AccountId;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -746,6 +701,7 @@ export interface TransferOwnership {
 }
 export declare type TransferOwnership__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -767,6 +723,7 @@ export interface UpdateInitialRoyalties {
 }
 export declare type UpdateInitialRoyalties__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -788,6 +745,7 @@ export interface UpdateRoyalties {
 }
 export declare type UpdateRoyalties__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -809,6 +767,7 @@ export interface UpdateAllowance {
 }
 export declare type UpdateAllowance__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -830,6 +789,7 @@ export interface UpdateUri {
 }
 export declare type UpdateUri__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -852,6 +812,7 @@ export interface AddWhitelistAccounts {
 }
 export declare type AddWhitelistAccounts__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -874,11 +835,12 @@ export interface UpdateWhitelistAccounts {
 }
 export declare type UpdateWhitelistAccounts__Result = boolean;
 /**
-* Contract wwill
+* End public sale/minting, going back to the pre-presale state in which no one can mint.
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
-export interface CloseContract {
+export interface CloseSale {
     args: {};
     options: {
         /** Units in gas
@@ -892,13 +854,14 @@ export interface CloseContract {
         attachedDeposit?: Balance;
     };
 }
-export declare type CloseContract__Result = boolean;
+export declare type CloseSale__Result = boolean;
 /**
 * Override the current presale start time to start presale now.
 * Most provide when public sale starts. None, means never.
 * Can provide new presale price.
 * Note: you most likely won't need to call this since the presale
 * starts automatically based on time.
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -921,6 +884,7 @@ export interface StartPresale {
 }
 export declare type StartPresale__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -943,6 +907,7 @@ export interface StartSale {
 export declare type StartSale__Result = boolean;
 /**
 * Add a new admin. Careful who you add!
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -966,6 +931,7 @@ export declare type AddAdmin__Result = boolean;
 /**
 * Update public sale price.
 * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -989,6 +955,7 @@ export declare type UpdatePrice__Result = boolean;
 /**
 * Update the presale price
 * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+* @allow ["::admins", "::owner"]
 *
 * @contractMethod change
 */
@@ -1009,6 +976,24 @@ export interface UpdatePresalePrice {
     };
 }
 export declare type UpdatePresalePrice__Result = boolean;
+/**
+* Current contract owner
+*
+* @contractMethod view
+*/
+export interface Owner {
+    args: {};
+}
+export declare type Owner__Result = AccountId;
+/**
+* Current set of admins
+*
+* @contractMethod view
+*/
+export interface Admins {
+    args: {};
+}
+export declare type Admins__Result = AccountId[];
 /**
 * Check whether an account is allowed to mint during the presale
 *
@@ -1130,15 +1115,6 @@ export interface Initial {
 }
 export declare type Initial__Result = u64;
 /**
-* Current set of admins
-*
-* @contractMethod view
-*/
-export interface Admins {
-    args: {};
-}
-export declare type Admins__Result = AccountId[];
-/**
 *
 * @contractMethod change
 */
@@ -1249,44 +1225,3 @@ export interface NftMintMany {
     };
 }
 export declare type NftMintMany__Result = Token[];
-/**
-*
-* @contractMethod change
-*/
-export interface OnSendWithCallback {
-    args: {};
-    options: {
-        /** Units in gas
-        * @pattern [0-9]+
-        * @default "30000000000000"
-        */
-        gas?: string;
-        /** Units in yoctoNear
-        * @default "0"
-        */
-        attachedDeposit?: Balance;
-    };
-}
-export declare type OnSendWithCallback__Result = void;
-/**
-*
-* @contractMethod change
-*/
-export interface LinkCallback {
-    args: {
-        account_id: AccountId;
-        mint_for_free: boolean;
-    };
-    options: {
-        /** Units in gas
-        * @pattern [0-9]+
-        * @default "30000000000000"
-        */
-        gas?: string;
-        /** Units in yoctoNear
-        * @default "0"
-        */
-        attachedDeposit?: Balance;
-    };
-}
-export declare type LinkCallback__Result = Token;

--- a/contracts/tenk/dist/index.js
+++ b/contracts/tenk/dist/index.js
@@ -106,70 +106,6 @@ var Contract = /** @class */ (function () {
         return helper_1.transactions.functionCall("create_linkdrop", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
     /**
-    * Allows given public key to claim sent balance.
-    * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-    * Claim tokens for specific account that are attached to the public key this tx is signed with.
-    */
-    Contract.prototype.claim = function (args, options) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _a, _b;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        _b = (_a = helper_1.providers).getTransactionLastResult;
-                        return [4 /*yield*/, this.claimRaw(args, options)];
-                    case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
-                }
-            });
-        });
-    };
-    /**
-    * Allows given public key to claim sent balance.
-    * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-    * Claim tokens for specific account that are attached to the public key this tx is signed with.
-    */
-    Contract.prototype.claimRaw = function (args, options) {
-        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "claim", args: args }, options));
-    };
-    /**
-    * Allows given public key to claim sent balance.
-    * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-    * Claim tokens for specific account that are attached to the public key this tx is signed with.
-    */
-    Contract.prototype.claimTx = function (args, options) {
-        var _a, _b;
-        return helper_1.transactions.functionCall("claim", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
-    };
-    /**
-    * Create new account and and claim tokens to it.
-    */
-    Contract.prototype.create_account_and_claim = function (args, options) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _a, _b;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        _b = (_a = helper_1.providers).getTransactionLastResult;
-                        return [4 /*yield*/, this.create_account_and_claimRaw(args, options)];
-                    case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
-                }
-            });
-        });
-    };
-    /**
-    * Create new account and and claim tokens to it.
-    */
-    Contract.prototype.create_account_and_claimRaw = function (args, options) {
-        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "create_account_and_claim", args: args }, options));
-    };
-    /**
-    * Create new account and and claim tokens to it.
-    */
-    Contract.prototype.create_account_and_claimTx = function (args, options) {
-        var _a, _b;
-        return helper_1.transactions.functionCall("create_account_and_claim", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
-    };
-    /**
     * Returns the balance associated with given key.
     */
     Contract.prototype.get_key_balance = function (args, options) {
@@ -179,30 +115,13 @@ var Contract = /** @class */ (function () {
     Contract.prototype.check_key = function (args, options) {
         return this.account.viewFunction(this.contractId, "check_key", args, options);
     };
-    Contract.prototype.on_create_and_claim = function (args, options) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _a, _b;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        _b = (_a = helper_1.providers).getTransactionLastResult;
-                        return [4 /*yield*/, this.on_create_and_claimRaw(args, options)];
-                    case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
-                }
-            });
-        });
-    };
-    Contract.prototype.on_create_and_claimRaw = function (args, options) {
-        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "on_create_and_claim", args: args }, options));
-    };
-    Contract.prototype.on_create_and_claimTx = function (args, options) {
-        var _a, _b;
-        return helper_1.transactions.functionCall("on_create_and_claim", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
-    };
     Contract.prototype.get_linkdrop_contract = function (args, options) {
         if (args === void 0) { args = {}; }
         return this.account.viewFunction(this.contractId, "get_linkdrop_contract", args, options);
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.transfer_ownership = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -216,13 +135,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.transfer_ownershipRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "transfer_ownership", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.transfer_ownershipTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("transfer_ownership", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_initial_royalties = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -236,13 +164,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_initial_royaltiesRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_initial_royalties", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_initial_royaltiesTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("update_initial_royalties", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_royalties = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -256,13 +193,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_royaltiesRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_royalties", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_royaltiesTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("update_royalties", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_allowance = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -276,13 +222,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_allowanceRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_allowance", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_allowanceTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("update_allowance", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_uri = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -296,13 +251,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_uriRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_uri", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_uriTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("update_uri", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.add_whitelist_accounts = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -316,13 +280,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.add_whitelist_accountsRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "add_whitelist_accounts", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.add_whitelist_accountsTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("add_whitelist_accounts", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_whitelist_accounts = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -336,17 +309,24 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_whitelist_accountsRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_whitelist_accounts", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.update_whitelist_accountsTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("update_whitelist_accounts", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
     /**
-    * Contract wwill
+    * End public sale/minting, going back to the pre-presale state in which no one can mint.
+    * @allow ["::admins", "::owner"]
     */
-    Contract.prototype.close_contract = function (args, options) {
+    Contract.prototype.close_sale = function (args, options) {
         if (args === void 0) { args = {}; }
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -354,26 +334,28 @@ var Contract = /** @class */ (function () {
                 switch (_c.label) {
                     case 0:
                         _b = (_a = helper_1.providers).getTransactionLastResult;
-                        return [4 /*yield*/, this.close_contractRaw(args, options)];
+                        return [4 /*yield*/, this.close_saleRaw(args, options)];
                     case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
                 }
             });
         });
     };
     /**
-    * Contract wwill
+    * End public sale/minting, going back to the pre-presale state in which no one can mint.
+    * @allow ["::admins", "::owner"]
     */
-    Contract.prototype.close_contractRaw = function (args, options) {
+    Contract.prototype.close_saleRaw = function (args, options) {
         if (args === void 0) { args = {}; }
-        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "close_contract", args: args }, options));
+        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "close_sale", args: args }, options));
     };
     /**
-    * Contract wwill
+    * End public sale/minting, going back to the pre-presale state in which no one can mint.
+    * @allow ["::admins", "::owner"]
     */
-    Contract.prototype.close_contractTx = function (args, options) {
+    Contract.prototype.close_saleTx = function (args, options) {
         var _a, _b;
         if (args === void 0) { args = {}; }
-        return helper_1.transactions.functionCall("close_contract", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
+        return helper_1.transactions.functionCall("close_sale", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
     /**
     * Override the current presale start time to start presale now.
@@ -381,6 +363,7 @@ var Contract = /** @class */ (function () {
     * Can provide new presale price.
     * Note: you most likely won't need to call this since the presale
     * starts automatically based on time.
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.start_presale = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
@@ -401,6 +384,7 @@ var Contract = /** @class */ (function () {
     * Can provide new presale price.
     * Note: you most likely won't need to call this since the presale
     * starts automatically based on time.
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.start_presaleRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "start_presale", args: args }, options));
@@ -411,11 +395,15 @@ var Contract = /** @class */ (function () {
     * Can provide new presale price.
     * Note: you most likely won't need to call this since the presale
     * starts automatically based on time.
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.start_presaleTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("start_presale", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.start_sale = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
             var _a, _b;
@@ -429,15 +417,22 @@ var Contract = /** @class */ (function () {
             });
         });
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.start_saleRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "start_sale", args: args }, options));
     };
+    /**
+    * @allow ["::admins", "::owner"]
+    */
     Contract.prototype.start_saleTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("start_sale", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
     /**
     * Add a new admin. Careful who you add!
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.add_admin = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
@@ -454,12 +449,14 @@ var Contract = /** @class */ (function () {
     };
     /**
     * Add a new admin. Careful who you add!
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.add_adminRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "add_admin", args: args }, options));
     };
     /**
     * Add a new admin. Careful who you add!
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.add_adminTx = function (args, options) {
         var _a, _b;
@@ -468,6 +465,7 @@ var Contract = /** @class */ (function () {
     /**
     * Update public sale price.
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.update_price = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
@@ -485,6 +483,7 @@ var Contract = /** @class */ (function () {
     /**
     * Update public sale price.
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.update_priceRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_price", args: args }, options));
@@ -492,6 +491,7 @@ var Contract = /** @class */ (function () {
     /**
     * Update public sale price.
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.update_priceTx = function (args, options) {
         var _a, _b;
@@ -500,6 +500,7 @@ var Contract = /** @class */ (function () {
     /**
     * Update the presale price
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.update_presale_price = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
@@ -517,6 +518,7 @@ var Contract = /** @class */ (function () {
     /**
     * Update the presale price
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.update_presale_priceRaw = function (args, options) {
         return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "update_presale_price", args: args }, options));
@@ -524,10 +526,25 @@ var Contract = /** @class */ (function () {
     /**
     * Update the presale price
     * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    * @allow ["::admins", "::owner"]
     */
     Contract.prototype.update_presale_priceTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("update_presale_price", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
+    };
+    /**
+    * Current contract owner
+    */
+    Contract.prototype.owner = function (args, options) {
+        if (args === void 0) { args = {}; }
+        return this.account.viewFunction(this.contractId, "owner", args, options);
+    };
+    /**
+    * Current set of admins
+    */
+    Contract.prototype.admins = function (args, options) {
+        if (args === void 0) { args = {}; }
+        return this.account.viewFunction(this.contractId, "admins", args, options);
     };
     /**
     * Check whether an account is allowed to mint during the presale
@@ -603,13 +620,6 @@ var Contract = /** @class */ (function () {
     Contract.prototype.initial = function (args, options) {
         if (args === void 0) { args = {}; }
         return this.account.viewFunction(this.contractId, "initial", args, options);
-    };
-    /**
-    * Current set of admins
-    */
-    Contract.prototype.admins = function (args, options) {
-        if (args === void 0) { args = {}; }
-        return this.account.viewFunction(this.contractId, "admins", args, options);
     };
     Contract.prototype.new_default_meta = function (args, options) {
         return __awaiter(this, void 0, void 0, function () {
@@ -713,49 +723,6 @@ var Contract = /** @class */ (function () {
     Contract.prototype.nft_mint_manyTx = function (args, options) {
         var _a, _b;
         return helper_1.transactions.functionCall("nft_mint_many", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
-    };
-    Contract.prototype.on_send_with_callback = function (args, options) {
-        if (args === void 0) { args = {}; }
-        return __awaiter(this, void 0, void 0, function () {
-            var _a, _b;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        _b = (_a = helper_1.providers).getTransactionLastResult;
-                        return [4 /*yield*/, this.on_send_with_callbackRaw(args, options)];
-                    case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
-                }
-            });
-        });
-    };
-    Contract.prototype.on_send_with_callbackRaw = function (args, options) {
-        if (args === void 0) { args = {}; }
-        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "on_send_with_callback", args: args }, options));
-    };
-    Contract.prototype.on_send_with_callbackTx = function (args, options) {
-        var _a, _b;
-        if (args === void 0) { args = {}; }
-        return helper_1.transactions.functionCall("on_send_with_callback", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
-    };
-    Contract.prototype.link_callback = function (args, options) {
-        return __awaiter(this, void 0, void 0, function () {
-            var _a, _b;
-            return __generator(this, function (_c) {
-                switch (_c.label) {
-                    case 0:
-                        _b = (_a = helper_1.providers).getTransactionLastResult;
-                        return [4 /*yield*/, this.link_callbackRaw(args, options)];
-                    case 1: return [2 /*return*/, _b.apply(_a, [_c.sent()])];
-                }
-            });
-        });
-    };
-    Contract.prototype.link_callbackRaw = function (args, options) {
-        return this.account.functionCall(__assign({ contractId: this.contractId, methodName: "link_callback", args: args }, options));
-    };
-    Contract.prototype.link_callbackTx = function (args, options) {
-        var _a, _b;
-        return helper_1.transactions.functionCall("link_callback", args, (_a = options === null || options === void 0 ? void 0 : options.gas) !== null && _a !== void 0 ? _a : helper_1.DEFAULT_FUNCTION_CALL_GAS, (_b = options === null || options === void 0 ? void 0 : options.attachedDeposit) !== null && _b !== void 0 ? _b : new helper_1.BN(0));
     };
     return Contract;
 }());

--- a/contracts/tenk/index.wit
+++ b/contracts/tenk/index.wit
@@ -7,70 +7,73 @@ type timestamp-ms = u64
 ///  Create a pending token that can be claimed with corresponding private key
 ///  change
 create-linkdrop: function(public-key: public-key)
-///  Allows given public key to claim sent balance.
-///  Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-///  Claim tokens for specific account that are attached to the public key this tx is signed with.
-///  change
-claim: function(account-id: account-id)
-///  Create new account and and claim tokens to it.
-///  change
-create-account-and-claim: function(new-account-id: account-id, new-public-key: public-key)
 ///  Returns the balance associated with given key.
 get-key-balance: function() -> u128
 
 check-key: function(public-key: public-key) -> bool
 
-///  change
-on-create-and-claim: function(mint-for-free: bool)
 get-linkdrop-contract: function() -> account-id
 
+///  @allow ["::admins", "::owner"]
 ///  change
 transfer-ownership: function(new-owner: account-id) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 update-initial-royalties: function(initial-royalties: royalties) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 update-royalties: function(royalties: royalties) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 update-allowance: function(allowance: u32) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 update-uri: function(uri: string) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 add-whitelist-accounts: function(accounts: list<account-id>, allowance: option<u32>) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 update-whitelist-accounts: function(accounts: list<account-id>, allowance-increase: u32) -> bool
 
-///  Contract wwill
+///  End public sale/minting, going back to the pre-presale state in which no one can mint.
+///  @allow ["::admins", "::owner"]
 ///  change
-close-contract: function() -> bool
+close-sale: function() -> bool
 
 ///  Override the current presale start time to start presale now.
 ///  Most provide when public sale starts. None, means never.
 ///  Can provide new presale price.
 ///  Note: you most likely won't need to call this since the presale
 ///  starts automatically based on time.
+///  @allow ["::admins", "::owner"]
 ///  change
 start-presale: function(public-sale-start: option<timestamp-ms>, presale-price: option<u128>) -> bool
 
+///  @allow ["::admins", "::owner"]
 ///  change
 start-sale: function(price: option<yocto-near>) -> bool
 
 ///  Add a new admin. Careful who you add!
+///  @allow ["::admins", "::owner"]
 ///  change
 add-admin: function(account-id: account-id) -> bool
 
 ///  Update public sale price. 
 ///  Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+///  @allow ["::admins", "::owner"]
 ///  change
 update-price: function(price: u128) -> bool
 
 ///  Update the presale price
 ///  Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+///  @allow ["::admins", "::owner"]
 ///  change
 update-presale-price: function(presale-price: option<u128>) -> bool
 
@@ -153,6 +156,12 @@ record sale-info {
 
 
 
+///  Current contract owner
+owner: function() -> account-id
+
+///  Current set of admins
+admins: function() -> list<account-id>
+
 ///  Check whether an account is allowed to mint during the presale
 whitelisted: function(account-id: account-id) -> bool
 
@@ -188,9 +197,6 @@ get-user-sale-info: function(account-id: account-id) -> user-sale-info
 ///  Initial size of collection. Number left to raffle + current total supply
 initial: function() -> u64
 
-///  Current set of admins
-admins: function() -> list<account-id>
-
 ///  change
 new-default-meta: function(owner-id: account-id, metadata: initial-metadata, size: u32, sale: option<sale>)
 ///  change
@@ -203,11 +209,6 @@ nft-mint-one: function() -> token
 
 ///  change
 nft-mint-many: function(num: u32) -> list<token>
-
-///  change
-on-send-with-callback: function()
-///  change
-link-callback: function(account-id: account-id, mint-for-free: bool) -> token
 // This is a generated file by witgen (https://github.com/bnjjj/witgen), please do not edit yourself, you can generate a new one thanks to cargo witgen generate command. (witme v0.2.0) 
 
 ///  StorageUsage is used to count the amount of storage used by a contract.

--- a/contracts/tenk/src/owner.rs
+++ b/contracts/tenk/src/owner.rs
@@ -4,6 +4,7 @@ use crate::*;
 impl Contract {
     // Owner private methods
 
+    /// @allow ["::admins", "::owner"]
     pub fn transfer_ownership(&mut self, new_owner: AccountId) -> bool {
         self.assert_owner();
         env::log_str(&format!(
@@ -14,6 +15,7 @@ impl Contract {
         true
     }
 
+    /// @allow ["::admins", "::owner"]
     pub fn update_initial_royalties(&mut self, initial_royalties: Royalties) -> bool {
         self.assert_owner_or_admin();
         initial_royalties.validate();
@@ -21,6 +23,7 @@ impl Contract {
         true
     }
 
+    /// @allow ["::admins", "::owner"]
     pub fn update_royalties(&mut self, royalties: Royalties) -> bool {
         self.assert_owner_or_admin();
         royalties.validate();
@@ -28,12 +31,14 @@ impl Contract {
         true
     }
 
+    /// @allow ["::admins", "::owner"]
     pub fn update_allowance(&mut self, allowance: u32) -> bool {
         self.assert_owner_or_admin();
         self.sale.allowance = Some(allowance);
         true
     }
 
+    /// @allow ["::admins", "::owner"]
     pub fn update_uri(&mut self, uri: String) -> bool {
         self.assert_owner_or_admin();
         let mut metadata = self.metadata.get().unwrap();
@@ -42,6 +47,8 @@ impl Contract {
         self.metadata.set(&metadata);
         true
     }
+
+    /// @allow ["::admins", "::owner"]
     pub fn add_whitelist_accounts(&mut self, accounts: Vec<AccountId>, allowance: Option<u32>) -> bool {
         #[cfg(feature = "testnet")]
         self.assert_owner_or_admin();
@@ -52,6 +59,7 @@ impl Contract {
         true
     }
 
+    /// @allow ["::admins", "::owner"]
     pub fn update_whitelist_accounts(&mut self, accounts: Vec<AccountId>, allowance_increase: u32) -> bool {
         self.assert_owner_or_admin();
         accounts.iter().for_each(|account_id| {
@@ -61,8 +69,9 @@ impl Contract {
         true
     }
 
-    /// Contract wwill
-    pub fn close_contract(&mut self) -> bool {
+    /// End public sale/minting, going back to the pre-presale state in which no one can mint.
+    /// @allow ["::admins", "::owner"]
+    pub fn close_sale(&mut self) -> bool {
         #[cfg(not(feature = "testnet"))]
         self.assert_owner_or_admin();
         self.sale.presale_start = None;
@@ -75,6 +84,7 @@ impl Contract {
     /// Can provide new presale price.
     /// Note: you most likely won't need to call this since the presale
     /// starts automatically based on time.
+    /// @allow ["::admins", "::owner"]
     pub fn start_presale(
         &mut self,
         public_sale_start: Option<TimestampMs>,
@@ -91,6 +101,7 @@ impl Contract {
         true
     }
 
+    /// @allow ["::admins", "::owner"]
     pub fn start_sale(&mut self, price: Option<YoctoNEAR>) -> bool {
         #[cfg(not(feature = "testnet"))]
         self.assert_owner_or_admin();
@@ -102,6 +113,7 @@ impl Contract {
     }
 
     /// Add a new admin. Careful who you add!
+    /// @allow ["::admins", "::owner"]
     pub fn add_admin(&mut self, account_id: AccountId) -> bool {
         self.assert_owner_or_admin();
         self.admins.insert(&account_id);
@@ -110,6 +122,7 @@ impl Contract {
 
     /// Update public sale price. 
     /// Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    /// @allow ["::admins", "::owner"]
     pub fn update_price(&mut self, price: U128) -> bool {
         self.assert_owner_or_admin();
         self.sale.price = price;
@@ -118,6 +131,7 @@ impl Contract {
 
     /// Update the presale price
     /// Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+    /// @allow ["::admins", "::owner"]
     pub fn update_presale_price(&mut self, presale_price: Option<U128>) -> bool {
         self.assert_owner_or_admin();
         self.sale.presale_price = presale_price;

--- a/contracts/tenk/src/views.rs
+++ b/contracts/tenk/src/views.rs
@@ -2,6 +2,16 @@ use crate::*;
 
 #[near_bindgen]
 impl Contract {
+    /// Current contract owner
+    pub fn owner(&self) -> AccountId {
+        self.tokens.owner_id.clone()
+    }
+
+    /// Current set of admins
+    pub fn admins(&self) -> Vec<AccountId> {
+        self.admins.to_vec()
+    }
+
     /// Check whether an account is allowed to mint during the presale
     pub fn whitelisted(&self, account_id: &AccountId) -> bool {
         self.whitelist.contains_key(account_id)
@@ -81,10 +91,5 @@ impl Contract {
     /// Initial size of collection. Number left to raffle + current total supply
     pub fn initial(&self) -> u64 {
       self.raffle.len() + self.nft_total_supply().0 as u64
-  }
-
-  /// Current set of admins
-  pub fn admins(&self) -> Vec<AccountId> {
-    self.admins.to_vec()
   }
 }

--- a/contracts/tenk/ts/index.ts
+++ b/contracts/tenk/ts/index.ts
@@ -248,63 +248,6 @@ export class Contract {
     return transactions.functionCall("create_linkdrop", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
   /**
-  * Allows given public key to claim sent balance.
-  * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-  * Claim tokens for specific account that are attached to the public key this tx is signed with.
-  */
-  async claim(args: {
-    account_id: AccountId;
-  }, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.claimRaw(args, options));
-  }
-  /**
-  * Allows given public key to claim sent balance.
-  * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-  * Claim tokens for specific account that are attached to the public key this tx is signed with.
-  */
-  claimRaw(args: {
-    account_id: AccountId;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "claim", args, ...options});
-  }
-  /**
-  * Allows given public key to claim sent balance.
-  * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-  * Claim tokens for specific account that are attached to the public key this tx is signed with.
-  */
-  claimTx(args: {
-    account_id: AccountId;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("claim", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
-  /**
-  * Create new account and and claim tokens to it.
-  */
-  async create_account_and_claim(args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  }, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.create_account_and_claimRaw(args, options));
-  }
-  /**
-  * Create new account and and claim tokens to it.
-  */
-  create_account_and_claimRaw(args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "create_account_and_claim", args, ...options});
-  }
-  /**
-  * Create new account and and claim tokens to it.
-  */
-  create_account_and_claimTx(args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("create_account_and_claim", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
-  /**
   * Returns the balance associated with given key.
   */
   get_key_balance(args = {}, options?: ViewFunctionOptions): Promise<U128> {
@@ -315,129 +258,177 @@ export class Contract {
   }, options?: ViewFunctionOptions): Promise<boolean> {
     return this.account.viewFunction(this.contractId, "check_key", args, options);
   }
-  async on_create_and_claim(args: {
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.on_create_and_claimRaw(args, options));
-  }
-  on_create_and_claimRaw(args: {
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "on_create_and_claim", args, ...options});
-  }
-  on_create_and_claimTx(args: {
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("on_create_and_claim", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
   get_linkdrop_contract(args = {}, options?: ViewFunctionOptions): Promise<AccountId> {
     return this.account.viewFunction(this.contractId, "get_linkdrop_contract", args, options);
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async transfer_ownership(args: {
     new_owner: AccountId;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.transfer_ownershipRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   transfer_ownershipRaw(args: {
     new_owner: AccountId;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "transfer_ownership", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   transfer_ownershipTx(args: {
     new_owner: AccountId;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("transfer_ownership", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_initial_royalties(args: {
     initial_royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_initial_royaltiesRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_initial_royaltiesRaw(args: {
     initial_royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_initial_royalties", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_initial_royaltiesTx(args: {
     initial_royalties: Royalties;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_initial_royalties", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_royalties(args: {
     royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_royaltiesRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_royaltiesRaw(args: {
     royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_royalties", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_royaltiesTx(args: {
     royalties: Royalties;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_royalties", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_allowance(args: {
     allowance: u32;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_allowanceRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_allowanceRaw(args: {
     allowance: u32;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_allowance", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_allowanceTx(args: {
     allowance: u32;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_allowance", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_uri(args: {
     uri: string;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_uriRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_uriRaw(args: {
     uri: string;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_uri", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_uriTx(args: {
     uri: string;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_uri", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async add_whitelist_accounts(args: {
     accounts: AccountId[];
     allowance?: u32;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.add_whitelist_accountsRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   add_whitelist_accountsRaw(args: {
     accounts: AccountId[];
     allowance?: u32;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "add_whitelist_accounts", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   add_whitelist_accountsTx(args: {
     accounts: AccountId[];
     allowance?: u32;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("add_whitelist_accounts", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_whitelist_accounts(args: {
     accounts: AccountId[];
     allowance_increase: u32;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_whitelist_accountsRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_whitelist_accountsRaw(args: {
     accounts: AccountId[];
     allowance_increase: u32;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_whitelist_accounts", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_whitelist_accountsTx(args: {
     accounts: AccountId[];
     allowance_increase: u32;
@@ -445,22 +436,25 @@ export class Contract {
     return transactions.functionCall("update_whitelist_accounts", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
   /**
-  * Contract wwill
+  * End public sale/minting, going back to the pre-presale state in which no one can mint.
+  * @allow ["::admins", "::owner"]
   */
-  async close_contract(args = {}, options?: ChangeMethodOptions): Promise<boolean> {
-    return providers.getTransactionLastResult(await this.close_contractRaw(args, options));
+  async close_sale(args = {}, options?: ChangeMethodOptions): Promise<boolean> {
+    return providers.getTransactionLastResult(await this.close_saleRaw(args, options));
   }
   /**
-  * Contract wwill
+  * End public sale/minting, going back to the pre-presale state in which no one can mint.
+  * @allow ["::admins", "::owner"]
   */
-  close_contractRaw(args = {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "close_contract", args, ...options});
+  close_saleRaw(args = {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
+    return this.account.functionCall({contractId: this.contractId, methodName: "close_sale", args, ...options});
   }
   /**
-  * Contract wwill
+  * End public sale/minting, going back to the pre-presale state in which no one can mint.
+  * @allow ["::admins", "::owner"]
   */
-  close_contractTx(args = {}, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("close_contract", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
+  close_saleTx(args = {}, options?: ChangeMethodOptions): transactions.Action {
+    return transactions.functionCall("close_sale", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
   /**
   * Override the current presale start time to start presale now.
@@ -468,6 +462,7 @@ export class Contract {
   * Can provide new presale price.
   * Note: you most likely won't need to call this since the presale
   * starts automatically based on time.
+  * @allow ["::admins", "::owner"]
   */
   async start_presale(args: {
     public_sale_start?: TimestampMs;
@@ -481,6 +476,7 @@ export class Contract {
   * Can provide new presale price.
   * Note: you most likely won't need to call this since the presale
   * starts automatically based on time.
+  * @allow ["::admins", "::owner"]
   */
   start_presaleRaw(args: {
     public_sale_start?: TimestampMs;
@@ -494,6 +490,7 @@ export class Contract {
   * Can provide new presale price.
   * Note: you most likely won't need to call this since the presale
   * starts automatically based on time.
+  * @allow ["::admins", "::owner"]
   */
   start_presaleTx(args: {
     public_sale_start?: TimestampMs;
@@ -501,16 +498,25 @@ export class Contract {
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("start_presale", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async start_sale(args: {
     price?: YoctoNear;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.start_saleRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   start_saleRaw(args: {
     price?: YoctoNear;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "start_sale", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   start_saleTx(args: {
     price?: YoctoNear;
   }, options?: ChangeMethodOptions): transactions.Action {
@@ -518,6 +524,7 @@ export class Contract {
   }
   /**
   * Add a new admin. Careful who you add!
+  * @allow ["::admins", "::owner"]
   */
   async add_admin(args: {
     account_id: AccountId;
@@ -526,6 +533,7 @@ export class Contract {
   }
   /**
   * Add a new admin. Careful who you add!
+  * @allow ["::admins", "::owner"]
   */
   add_adminRaw(args: {
     account_id: AccountId;
@@ -534,6 +542,7 @@ export class Contract {
   }
   /**
   * Add a new admin. Careful who you add!
+  * @allow ["::admins", "::owner"]
   */
   add_adminTx(args: {
     account_id: AccountId;
@@ -543,6 +552,7 @@ export class Contract {
   /**
   * Update public sale price.
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   async update_price(args: {
     price: U128;
@@ -552,6 +562,7 @@ export class Contract {
   /**
   * Update public sale price.
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_priceRaw(args: {
     price: U128;
@@ -561,6 +572,7 @@ export class Contract {
   /**
   * Update public sale price.
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_priceTx(args: {
     price: U128;
@@ -570,6 +582,7 @@ export class Contract {
   /**
   * Update the presale price
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   async update_presale_price(args: {
     presale_price?: U128;
@@ -579,6 +592,7 @@ export class Contract {
   /**
   * Update the presale price
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_presale_priceRaw(args: {
     presale_price?: U128;
@@ -588,11 +602,24 @@ export class Contract {
   /**
   * Update the presale price
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_presale_priceTx(args: {
     presale_price?: U128;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_presale_price", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
+  }
+  /**
+  * Current contract owner
+  */
+  owner(args = {}, options?: ViewFunctionOptions): Promise<AccountId> {
+    return this.account.viewFunction(this.contractId, "owner", args, options);
+  }
+  /**
+  * Current set of admins
+  */
+  admins(args = {}, options?: ViewFunctionOptions): Promise<AccountId[]> {
+    return this.account.viewFunction(this.contractId, "admins", args, options);
   }
   /**
   * Check whether an account is allowed to mint during the presale
@@ -675,12 +702,6 @@ export class Contract {
   */
   initial(args = {}, options?: ViewFunctionOptions): Promise<u64> {
     return this.account.viewFunction(this.contractId, "initial", args, options);
-  }
-  /**
-  * Current set of admins
-  */
-  admins(args = {}, options?: ViewFunctionOptions): Promise<AccountId[]> {
-    return this.account.viewFunction(this.contractId, "admins", args, options);
   }
   async new_default_meta(args: {
     owner_id: AccountId;
@@ -775,33 +796,6 @@ export class Contract {
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("nft_mint_many", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
-  async on_send_with_callback(args = {}, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.on_send_with_callbackRaw(args, options));
-  }
-  on_send_with_callbackRaw(args = {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "on_send_with_callback", args, ...options});
-  }
-  on_send_with_callbackTx(args = {}, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("on_send_with_callback", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
-  async link_callback(args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<Token> {
-    return providers.getTransactionLastResult(await this.link_callbackRaw(args, options));
-  }
-  link_callbackRaw(args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "link_callback", args, ...options});
-  }
-  link_callbackTx(args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("link_callback", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
 }
 /**
 * Create a pending token that can be claimed with corresponding private key
@@ -827,55 +821,6 @@ export interface CreateLinkdrop {
 }
 export type CreateLinkdrop__Result = void;
 /**
-* Allows given public key to claim sent balance.
-* Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-* Claim tokens for specific account that are attached to the public key this tx is signed with.
-* 
-* @contractMethod change
-*/
-export interface Claim {
-  args: {
-    account_id: AccountId;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type Claim__Result = void;
-/**
-* Create new account and and claim tokens to it.
-* 
-* @contractMethod change
-*/
-export interface CreateAccountAndClaim {
-  args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type CreateAccountAndClaim__Result = void;
-/**
 * Returns the balance associated with given key.
 * 
 * @contractMethod view
@@ -898,28 +843,6 @@ export interface CheckKey {
 export type CheckKey__Result = boolean;
 /**
 * 
-* @contractMethod change
-*/
-export interface OnCreateAndClaim {
-  args: {
-    mint_for_free: boolean;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type OnCreateAndClaim__Result = void;
-/**
-* 
 * @contractMethod view
 */
 export interface GetLinkdropContract {
@@ -928,6 +851,7 @@ export interface GetLinkdropContract {
 }
 export type GetLinkdropContract__Result = AccountId;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -950,6 +874,7 @@ export interface TransferOwnership {
 }
 export type TransferOwnership__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -972,6 +897,7 @@ export interface UpdateInitialRoyalties {
 }
 export type UpdateInitialRoyalties__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -994,6 +920,7 @@ export interface UpdateRoyalties {
 }
 export type UpdateRoyalties__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1016,6 +943,7 @@ export interface UpdateAllowance {
 }
 export type UpdateAllowance__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1038,6 +966,7 @@ export interface UpdateUri {
 }
 export type UpdateUri__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1061,6 +990,7 @@ export interface AddWhitelistAccounts {
 }
 export type AddWhitelistAccounts__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1084,11 +1014,12 @@ export interface UpdateWhitelistAccounts {
 }
 export type UpdateWhitelistAccounts__Result = boolean;
 /**
-* Contract wwill
+* End public sale/minting, going back to the pre-presale state in which no one can mint.
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
-export interface CloseContract {
+export interface CloseSale {
   args: {};
   options: {
     /** Units in gas
@@ -1103,13 +1034,14 @@ export interface CloseContract {
   }
   
 }
-export type CloseContract__Result = boolean;
+export type CloseSale__Result = boolean;
 /**
 * Override the current presale start time to start presale now.
 * Most provide when public sale starts. None, means never.
 * Can provide new presale price.
 * Note: you most likely won't need to call this since the presale
 * starts automatically based on time.
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1133,6 +1065,7 @@ export interface StartPresale {
 }
 export type StartPresale__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1156,6 +1089,7 @@ export interface StartSale {
 export type StartSale__Result = boolean;
 /**
 * Add a new admin. Careful who you add!
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1180,6 +1114,7 @@ export type AddAdmin__Result = boolean;
 /**
 * Update public sale price.
 * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1204,6 +1139,7 @@ export type UpdatePrice__Result = boolean;
 /**
 * Update the presale price
 * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1225,6 +1161,26 @@ export interface UpdatePresalePrice {
   
 }
 export type UpdatePresalePrice__Result = boolean;
+/**
+* Current contract owner
+* 
+* @contractMethod view
+*/
+export interface Owner {
+  args: {};
+  
+}
+export type Owner__Result = AccountId;
+/**
+* Current set of admins
+* 
+* @contractMethod view
+*/
+export interface Admins {
+  args: {};
+  
+}
+export type Admins__Result = AccountId[];
 /**
 * Check whether an account is allowed to mint during the presale
 * 
@@ -1358,16 +1314,6 @@ export interface Initial {
 }
 export type Initial__Result = u64;
 /**
-* Current set of admins
-* 
-* @contractMethod view
-*/
-export interface Admins {
-  args: {};
-  
-}
-export type Admins__Result = AccountId[];
-/**
 * 
 * @contractMethod change
 */
@@ -1483,46 +1429,3 @@ export interface NftMintMany {
   
 }
 export type NftMintMany__Result = Token[];
-/**
-* 
-* @contractMethod change
-*/
-export interface OnSendWithCallback {
-  args: {};
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type OnSendWithCallback__Result = void;
-/**
-* 
-* @contractMethod change
-*/
-export interface LinkCallback {
-  args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type LinkCallback__Result = Token;

--- a/gui/src/components/Selector/Selector.tsx
+++ b/gui/src/components/Selector/Selector.tsx
@@ -1,26 +1,61 @@
-import * as React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import snake from "to-snake-case";
-import { MethodName, changeMethods, viewMethods } from "../../near/methods";
+import {
+  MethodName,
+  adminMethods,
+  changeMethods,
+  viewMethods
+} from "../../near/methods";
 import { Dropdown } from ".."
+import useNear from '../../hooks/useNear'
 
-export const Selector: React.FC<React.PropsWithChildren<{
+type Item = {
+  children: string
+  onSelect: () => void
+}
+
+type Items = {
+  'Admin Methods'?: Item[]
+  'Change Methods'?: Item[]
+  'View Methods': Item[]
+}
+
+export const Selector: React.FC<{
   value?: string
   onSelected: (method: MethodName) => void
-}>> = ({ value, onSelected }) => {
-  const toItem = (method: MethodName) => ({
+}> = ({ value, onSelected }) => {
+  const { wallet, TenK } = useNear()
+  const [admins, setAdmins] = useState<string[]>()
+
+  useEffect(() => {
+    TenK?.admins().then(setAdmins)
+  }, [wallet, TenK])
+
+  const toItem = useMemo(() => (method: MethodName) => ({
     children: snake(method),
     onSelect: () => {
       onSelected(method);
     },
-  })
+  }), [onSelected])
+
+  const items: Items = useMemo(() => {
+    const user = wallet?.getAccountId() as string
+    const isAdmin = admins?.includes(user)
+
+    const ret: Items = { 'View Methods': viewMethods.map(toItem) }
+    if (user) ret['Change Methods'] = changeMethods.map(toItem)
+    if (isAdmin) ret['Admin Methods'] = adminMethods.map(toItem)
+
+    return ret
+  }, [wallet, toItem, admins])
 
   return (
     <Dropdown
       trigger={value ?? "Select contract method"}
-      items={{
-        'Change Methods': changeMethods.map(toItem),
-        'View Methods': viewMethods.map(toItem),
-      }}
+      items={Object.keys(items).length === 1
+        ? items['View Methods']
+        : items
+      }
     />
   )
 }

--- a/gui/src/near/contracts/tenk/index.schema.json
+++ b/gui/src/near/contracts/tenk/index.schema.json
@@ -9,6 +9,10 @@
     },
     "AddAdmin": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "description": "Add a new admin. Careful who you add!",
       "properties": {
@@ -53,6 +57,10 @@
     },
     "AddWhitelistAccounts": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -157,10 +165,14 @@
     "CheckKey__Result": {
       "type": "boolean"
     },
-    "CloseContract": {
+    "CloseSale": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
-      "description": "Contract wwill",
+      "description": "End public sale/minting, going back to the pre-presale state in which no one can mint.",
       "properties": {
         "args": {
           "additionalProperties": false,
@@ -190,7 +202,7 @@
       ],
       "type": "object"
     },
-    "CloseContract__Result": {
+    "CloseSale__Result": {
       "type": "boolean"
     },
     "CostOfLinkdrop": {
@@ -593,57 +605,6 @@
     "New__Result": {
       "type": "null"
     },
-    "NftApprove": {
-      "additionalProperties": false,
-      "contractMethod": "change",
-      "description": "Add an approved account for a specific token.\n\nRequirements\n* Caller of the method must attach a deposit of at least 1 yoctoⓃ for security purposes\n* Contract MAY require caller to attach larger deposit, to cover cost of storing approver data\n* Contract MUST panic if called by someone other than token owner\n* Contract MUST panic if addition would cause `nft_revoke_all` to exceed single-block gas limit\n* Contract MUST increment approval ID even if re-approving an account\n* If successfully approved or if had already been approved, and if `msg` is present, contract MUST call `nft_on_approve` on `account_id`. See `nft_on_approve` description below for details.\n\nArguments:\n* `token_id`: the token for which to add an approval\n* `account_id`: the account to add to `approvals`\n* `msg`: optional string to be passed to `nft_on_approve`\n\nReturns void, if no `msg` given. Otherwise, returns promise call to `nft_on_approve`, which can resolve with whatever it wants.",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "account_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "msg": {
-              "type": "string"
-            },
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "token_id",
-            "account_id"
-          ],
-          "type": "object"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "attachedDeposit": {
-              "$ref": "#/definitions/Balance",
-              "default": "0",
-              "description": "Units in yoctoNear"
-            },
-            "gas": {
-              "default": "30000000000000",
-              "description": "Units in gas",
-              "pattern": "[0-9]+",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args",
-        "options"
-      ],
-      "type": "object"
-    },
-    "NftApprove__Result": {
-      "type": "null"
-    },
     "NftContractMetadata": {
       "additionalProperties": false,
       "description": "Metadata for the NFT contract itself.",
@@ -676,39 +637,6 @@
         "symbol"
       ],
       "type": "object"
-    },
-    "NftIsApproved": {
-      "additionalProperties": false,
-      "contractMethod": "view",
-      "description": "Check if a token is approved for transfer by a given account, optionally checking an approval_id\n\nArguments:\n* `token_id`: the token for which to revoke an approval\n* `approved_account_id`: the account to check the existence of in `approvals`\n* `approval_id`: an optional approval ID to check against current approval ID for given account\n\nReturns: if `approval_id` given, `true` if `approved_account_id` is approved with given `approval_id` otherwise, `true` if `approved_account_id` is in list of approved accounts",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "approval_id": {
-              "$ref": "#/definitions/u64"
-            },
-            "approved_account_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "token_id",
-            "approved_account_id"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "args"
-      ],
-      "type": "object"
-    },
-    "NftIsApproved__Result": {
-      "type": "boolean"
     },
     "NftMetadata": {
       "additionalProperties": false,
@@ -860,257 +788,10 @@
     "NftMint__Result": {
       "$ref": "#/definitions/Token"
     },
-    "NftPayout": {
+    "Owner": {
       "additionalProperties": false,
       "contractMethod": "view",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "balance": {
-              "$ref": "#/definitions/U128"
-            },
-            "max_len_payout": {
-              "$ref": "#/definitions/u32"
-            },
-            "token_id": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "token_id",
-            "balance"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "args"
-      ],
-      "type": "object"
-    },
-    "NftPayout__Result": {
-      "$ref": "#/definitions/Payout"
-    },
-    "NftRevoke": {
-      "additionalProperties": false,
-      "contractMethod": "change",
-      "description": "Revoke an approved account for a specific token.\n\nRequirements\n* Caller of the method must attach a deposit of 1 yoctoⓃ for security purposes\n* If contract requires >1yN deposit on `nft_approve`, contract MUST refund associated storage deposit when owner revokes approval\n* Contract MUST panic if called by someone other than token owner\n\nArguments:\n* `token_id`: the token for which to revoke an approval\n* `account_id`: the account to remove from `approvals`",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "account_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "token_id",
-            "account_id"
-          ],
-          "type": "object"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "attachedDeposit": {
-              "$ref": "#/definitions/Balance",
-              "default": "0",
-              "description": "Units in yoctoNear"
-            },
-            "gas": {
-              "default": "30000000000000",
-              "description": "Units in gas",
-              "pattern": "[0-9]+",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args",
-        "options"
-      ],
-      "type": "object"
-    },
-    "NftRevokeAll": {
-      "additionalProperties": false,
-      "contractMethod": "change",
-      "description": "Revoke all approved accounts for a specific token.\n\nRequirements\n* Caller of the method must attach a deposit of 1 yoctoⓃ for security purposes\n* If contract requires >1yN deposit on `nft_approve`, contract MUST refund all associated storage deposit when owner revokes approvals\n* Contract MUST panic if called by someone other than token owner\n\nArguments:\n* `token_id`: the token with approvals to revoke",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "token_id"
-          ],
-          "type": "object"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "attachedDeposit": {
-              "$ref": "#/definitions/Balance",
-              "default": "0",
-              "description": "Units in yoctoNear"
-            },
-            "gas": {
-              "default": "30000000000000",
-              "description": "Units in gas",
-              "pattern": "[0-9]+",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args",
-        "options"
-      ],
-      "type": "object"
-    },
-    "NftRevokeAll__Result": {
-      "type": "null"
-    },
-    "NftRevoke__Result": {
-      "type": "null"
-    },
-    "NftSupplyForOwner": {
-      "additionalProperties": false,
-      "contractMethod": "view",
-      "description": "Get number of tokens owned by a given account\n\nArguments:\n* `account_id`: a valid NEAR account\n\nReturns the number of non-fungible tokens owned by given `account_id` as a string representing the value as an unsigned 128-bit integer to avoid JSON number limit of 2^53.",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "account_id": {
-              "$ref": "#/definitions/AccountId"
-            }
-          },
-          "required": [
-            "account_id"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "args"
-      ],
-      "type": "object"
-    },
-    "NftSupplyForOwner__Result": {
-      "$ref": "#/definitions/U128"
-    },
-    "NftToken": {
-      "additionalProperties": false,
-      "contractMethod": "view",
-      "description": "Returns the token with the given `token_id` or `null` if no such token.",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "token_id"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "args"
-      ],
-      "type": "object"
-    },
-    "NftToken__Result": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Token"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "NftTokens": {
-      "additionalProperties": false,
-      "contractMethod": "view",
-      "description": "Get a list of all tokens\n\nArguments:\n* `from_index`: a string representing an unsigned 128-bit integer, representing the starting index of tokens to return. (default 0)\n* `limit`: the maximum number of tokens to return (default total supply) Could fail on gas\n\nReturns an array of Token objects, as described in Core standard",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "from_index": {
-              "$ref": "#/definitions/U128"
-            },
-            "limit": {
-              "$ref": "#/definitions/u64"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args"
-      ],
-      "type": "object"
-    },
-    "NftTokensForOwner": {
-      "additionalProperties": false,
-      "contractMethod": "view",
-      "description": "Get list of all tokens owned by a given account\n\nArguments:\n* `account_id`: a valid NEAR account\n* `from_index`: a string representing an unsigned 128-bit integer, representing the starting index of tokens to return. (default 0)\n* `limit`: the maximum number of tokens to return. (default unlimited) Could fail on gas\n\nReturns a paginated list of all tokens owned by this account",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "account_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "from_index": {
-              "$ref": "#/definitions/U128"
-            },
-            "limit": {
-              "$ref": "#/definitions/u64"
-            }
-          },
-          "required": [
-            "account_id"
-          ],
-          "type": "object"
-        }
-      },
-      "required": [
-        "args"
-      ],
-      "type": "object"
-    },
-    "NftTokensForOwner__Result": {
-      "items": {
-        "$ref": "#/definitions/Token"
-      },
-      "type": "array"
-    },
-    "NftTokens__Result": {
-      "items": {
-        "$ref": "#/definitions/Token"
-      },
-      "type": "array"
-    },
-    "NftTotalSupply": {
-      "additionalProperties": false,
-      "contractMethod": "view",
-      "description": "Returns the total supply of non-fungible tokens as a string representing an unsigned 128-bit integer to avoid JSON number limit of 2^53.",
+      "description": "Current contract owner",
       "properties": {
         "args": {
           "additionalProperties": false,
@@ -1122,180 +803,8 @@
       ],
       "type": "object"
     },
-    "NftTotalSupply__Result": {
-      "$ref": "#/definitions/U128"
-    },
-    "NftTransfer": {
-      "additionalProperties": false,
-      "contractMethod": "change",
-      "description": "Simple transfer. Transfer a given `token_id` from current owner to `receiver_id`.\n\nRequirements\n* Caller of the method must attach a deposit of 1 yoctoⓃ for security purposes\n* Contract MUST panic if called by someone other than token owner or, if using Approval Management, one of the approved accounts\n* `approval_id` is for use with Approval Management, see <https://nomicon.io/Standards/NonFungibleToken/ApprovalManagement.html>\n* If using Approval Management, contract MUST nullify approved accounts on successful transfer.\n* TODO: needed? Both accounts must be registered with the contract for transfer to succeed. See see <https://nomicon.io/Standards/StorageManagement.html>\n\nArguments:\n* `receiver_id`: the valid NEAR account receiving the token\n* `token_id`: the token to transfer\n* `approval_id`: expected approval ID. A number smaller than 2^53, and therefore representable as JSON. See Approval Management standard for full explanation.\n* `memo` (optional): for use cases that may benefit from indexing or providing information for a transfer",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "approval_id": {
-              "$ref": "#/definitions/u64"
-            },
-            "memo": {
-              "type": "string"
-            },
-            "receiver_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "receiver_id",
-            "token_id"
-          ],
-          "type": "object"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "attachedDeposit": {
-              "$ref": "#/definitions/Balance",
-              "default": "0",
-              "description": "Units in yoctoNear"
-            },
-            "gas": {
-              "default": "30000000000000",
-              "description": "Units in gas",
-              "pattern": "[0-9]+",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args",
-        "options"
-      ],
-      "type": "object"
-    },
-    "NftTransferCall": {
-      "additionalProperties": false,
-      "contractMethod": "change",
-      "description": "Transfer token and call a method on a receiver contract. A successful workflow will end in a success execution outcome to the callback on the NFT contract at the method `nft_resolve_transfer`.\n\nYou can think of this as being similar to attaching native NEAR tokens to a function call. It allows you to attach any Non-Fungible Token in a call to a receiver contract.\n\nRequirements:\n* Caller of the method must attach a deposit of 1 yoctoⓃ for security purposes\n* Contract MUST panic if called by someone other than token owner or, if using Approval Management, one of the approved accounts\n* The receiving contract must implement `ft_on_transfer` according to the standard. If it does not, FT contract's `ft_resolve_transfer` MUST deal with the resulting failed cross-contract call and roll back the transfer.\n* Contract MUST implement the behavior described in `ft_resolve_transfer`\n* `approval_id` is for use with Approval Management extension, see that document for full explanation.\n* If using Approval Management, contract MUST nullify approved accounts on successful transfer.\n\nArguments:\n* `receiver_id`: the valid NEAR account receiving the token.\n* `token_id`: the token to send.\n* `approval_id`: expected approval ID. A number smaller than 2^53, and therefore representable as JSON. See Approval Management standard for full explanation.\n* `memo` (optional): for use cases that may benefit from indexing or providing information for a transfer.\n* `msg`: specifies information needed by the receiving contract in order to properly handle the transfer. Can indicate both a function to call and the parameters to pass to that function.",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "approval_id": {
-              "$ref": "#/definitions/u64"
-            },
-            "memo": {
-              "type": "string"
-            },
-            "msg": {
-              "type": "string"
-            },
-            "receiver_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "token_id": {
-              "$ref": "#/definitions/TokenId"
-            }
-          },
-          "required": [
-            "receiver_id",
-            "token_id",
-            "msg"
-          ],
-          "type": "object"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "attachedDeposit": {
-              "$ref": "#/definitions/Balance",
-              "default": "0",
-              "description": "Units in yoctoNear"
-            },
-            "gas": {
-              "default": "30000000000000",
-              "description": "Units in gas",
-              "pattern": "[0-9]+",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args",
-        "options"
-      ],
-      "type": "object"
-    },
-    "NftTransferCall__Result": {
-      "type": "null"
-    },
-    "NftTransferPayout": {
-      "additionalProperties": false,
-      "contractMethod": "change",
-      "properties": {
-        "args": {
-          "additionalProperties": false,
-          "properties": {
-            "approval_id": {
-              "$ref": "#/definitions/u64"
-            },
-            "balance": {
-              "$ref": "#/definitions/U128"
-            },
-            "max_len_payout": {
-              "$ref": "#/definitions/u32"
-            },
-            "memo": {
-              "type": "string"
-            },
-            "receiver_id": {
-              "$ref": "#/definitions/AccountId"
-            },
-            "token_id": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "receiver_id",
-            "token_id",
-            "balance"
-          ],
-          "type": "object"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "attachedDeposit": {
-              "$ref": "#/definitions/Balance",
-              "default": "0",
-              "description": "Units in yoctoNear"
-            },
-            "gas": {
-              "default": "30000000000000",
-              "description": "Units in gas",
-              "pattern": "[0-9]+",
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "args",
-        "options"
-      ],
-      "type": "object"
-    },
-    "NftTransferPayout__Result": {
-      "$ref": "#/definitions/Payout"
-    },
-    "NftTransfer__Result": {
-      "type": "null"
+    "Owner__Result": {
+      "$ref": "#/definitions/AccountId"
     },
     "Payout": {
       "additionalProperties": false,
@@ -1438,6 +947,10 @@
     },
     "StartPresale": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "description": "Override the current presale start time to start presale now. Most provide when public sale starts. None, means never. Can provide new presale price. Note: you most likely won't need to call this since the presale starts automatically based on time.",
       "properties": {
@@ -1482,6 +995,10 @@
     },
     "StartSale": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -1713,6 +1230,10 @@
     },
     "TransferOwnership": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -1761,6 +1282,10 @@
     },
     "UpdateAllowance": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -1804,6 +1329,10 @@
     },
     "UpdateInitialRoyalties": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -1847,6 +1376,10 @@
     },
     "UpdatePresalePrice": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "description": "Update the presale price Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN",
       "properties": {
@@ -1888,6 +1421,10 @@
     },
     "UpdatePrice": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "description": "Update public sale price. Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN",
       "properties": {
@@ -1932,6 +1469,10 @@
     },
     "UpdateRoyalties": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -1975,6 +1516,10 @@
     },
     "UpdateUri": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {
@@ -2018,6 +1563,10 @@
     },
     "UpdateWhitelistAccounts": {
       "additionalProperties": false,
+      "allow": [
+        "::admins",
+        "::owner"
+      ],
       "contractMethod": "change",
       "properties": {
         "args": {

--- a/gui/src/near/contracts/tenk/index.ts
+++ b/gui/src/near/contracts/tenk/index.ts
@@ -248,63 +248,6 @@ export class Contract {
     return transactions.functionCall("create_linkdrop", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
   /**
-  * Allows given public key to claim sent balance.
-  * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-  * Claim tokens for specific account that are attached to the public key this tx is signed with.
-  */
-  async claim(args: {
-    account_id: AccountId;
-  }, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.claimRaw(args, options));
-  }
-  /**
-  * Allows given public key to claim sent balance.
-  * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-  * Claim tokens for specific account that are attached to the public key this tx is signed with.
-  */
-  claimRaw(args: {
-    account_id: AccountId;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "claim", args, ...options});
-  }
-  /**
-  * Allows given public key to claim sent balance.
-  * Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-  * Claim tokens for specific account that are attached to the public key this tx is signed with.
-  */
-  claimTx(args: {
-    account_id: AccountId;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("claim", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
-  /**
-  * Create new account and and claim tokens to it.
-  */
-  async create_account_and_claim(args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  }, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.create_account_and_claimRaw(args, options));
-  }
-  /**
-  * Create new account and and claim tokens to it.
-  */
-  create_account_and_claimRaw(args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "create_account_and_claim", args, ...options});
-  }
-  /**
-  * Create new account and and claim tokens to it.
-  */
-  create_account_and_claimTx(args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("create_account_and_claim", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
-  /**
   * Returns the balance associated with given key.
   */
   get_key_balance(args = {}, options?: ViewFunctionOptions): Promise<U128> {
@@ -315,129 +258,177 @@ export class Contract {
   }, options?: ViewFunctionOptions): Promise<boolean> {
     return this.account.viewFunction(this.contractId, "check_key", args, options);
   }
-  async on_create_and_claim(args: {
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.on_create_and_claimRaw(args, options));
-  }
-  on_create_and_claimRaw(args: {
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "on_create_and_claim", args, ...options});
-  }
-  on_create_and_claimTx(args: {
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("on_create_and_claim", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
   get_linkdrop_contract(args = {}, options?: ViewFunctionOptions): Promise<AccountId> {
     return this.account.viewFunction(this.contractId, "get_linkdrop_contract", args, options);
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async transfer_ownership(args: {
     new_owner: AccountId;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.transfer_ownershipRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   transfer_ownershipRaw(args: {
     new_owner: AccountId;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "transfer_ownership", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   transfer_ownershipTx(args: {
     new_owner: AccountId;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("transfer_ownership", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_initial_royalties(args: {
     initial_royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_initial_royaltiesRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_initial_royaltiesRaw(args: {
     initial_royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_initial_royalties", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_initial_royaltiesTx(args: {
     initial_royalties: Royalties;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_initial_royalties", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_royalties(args: {
     royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_royaltiesRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_royaltiesRaw(args: {
     royalties: Royalties;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_royalties", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_royaltiesTx(args: {
     royalties: Royalties;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_royalties", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_allowance(args: {
     allowance: u32;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_allowanceRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_allowanceRaw(args: {
     allowance: u32;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_allowance", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_allowanceTx(args: {
     allowance: u32;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_allowance", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_uri(args: {
     uri: string;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_uriRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_uriRaw(args: {
     uri: string;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_uri", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_uriTx(args: {
     uri: string;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_uri", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async add_whitelist_accounts(args: {
     accounts: AccountId[];
     allowance?: u32;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.add_whitelist_accountsRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   add_whitelist_accountsRaw(args: {
     accounts: AccountId[];
     allowance?: u32;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "add_whitelist_accounts", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   add_whitelist_accountsTx(args: {
     accounts: AccountId[];
     allowance?: u32;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("add_whitelist_accounts", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async update_whitelist_accounts(args: {
     accounts: AccountId[];
     allowance_increase: u32;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.update_whitelist_accountsRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_whitelist_accountsRaw(args: {
     accounts: AccountId[];
     allowance_increase: u32;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "update_whitelist_accounts", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   update_whitelist_accountsTx(args: {
     accounts: AccountId[];
     allowance_increase: u32;
@@ -445,22 +436,25 @@ export class Contract {
     return transactions.functionCall("update_whitelist_accounts", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
   /**
-  * Contract wwill
+  * End public sale/minting, going back to the pre-presale state in which no one can mint.
+  * @allow ["::admins", "::owner"]
   */
-  async close_contract(args = {}, options?: ChangeMethodOptions): Promise<boolean> {
-    return providers.getTransactionLastResult(await this.close_contractRaw(args, options));
+  async close_sale(args = {}, options?: ChangeMethodOptions): Promise<boolean> {
+    return providers.getTransactionLastResult(await this.close_saleRaw(args, options));
   }
   /**
-  * Contract wwill
+  * End public sale/minting, going back to the pre-presale state in which no one can mint.
+  * @allow ["::admins", "::owner"]
   */
-  close_contractRaw(args = {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "close_contract", args, ...options});
+  close_saleRaw(args = {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
+    return this.account.functionCall({contractId: this.contractId, methodName: "close_sale", args, ...options});
   }
   /**
-  * Contract wwill
+  * End public sale/minting, going back to the pre-presale state in which no one can mint.
+  * @allow ["::admins", "::owner"]
   */
-  close_contractTx(args = {}, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("close_contract", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
+  close_saleTx(args = {}, options?: ChangeMethodOptions): transactions.Action {
+    return transactions.functionCall("close_sale", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
   /**
   * Override the current presale start time to start presale now.
@@ -468,6 +462,7 @@ export class Contract {
   * Can provide new presale price.
   * Note: you most likely won't need to call this since the presale
   * starts automatically based on time.
+  * @allow ["::admins", "::owner"]
   */
   async start_presale(args: {
     public_sale_start?: TimestampMs;
@@ -481,6 +476,7 @@ export class Contract {
   * Can provide new presale price.
   * Note: you most likely won't need to call this since the presale
   * starts automatically based on time.
+  * @allow ["::admins", "::owner"]
   */
   start_presaleRaw(args: {
     public_sale_start?: TimestampMs;
@@ -494,6 +490,7 @@ export class Contract {
   * Can provide new presale price.
   * Note: you most likely won't need to call this since the presale
   * starts automatically based on time.
+  * @allow ["::admins", "::owner"]
   */
   start_presaleTx(args: {
     public_sale_start?: TimestampMs;
@@ -501,16 +498,25 @@ export class Contract {
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("start_presale", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   async start_sale(args: {
     price?: YoctoNear;
   }, options?: ChangeMethodOptions): Promise<boolean> {
     return providers.getTransactionLastResult(await this.start_saleRaw(args, options));
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   start_saleRaw(args: {
     price?: YoctoNear;
   }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
     return this.account.functionCall({contractId: this.contractId, methodName: "start_sale", args, ...options});
   }
+  /**
+  * @allow ["::admins", "::owner"]
+  */
   start_saleTx(args: {
     price?: YoctoNear;
   }, options?: ChangeMethodOptions): transactions.Action {
@@ -518,6 +524,7 @@ export class Contract {
   }
   /**
   * Add a new admin. Careful who you add!
+  * @allow ["::admins", "::owner"]
   */
   async add_admin(args: {
     account_id: AccountId;
@@ -526,6 +533,7 @@ export class Contract {
   }
   /**
   * Add a new admin. Careful who you add!
+  * @allow ["::admins", "::owner"]
   */
   add_adminRaw(args: {
     account_id: AccountId;
@@ -534,6 +542,7 @@ export class Contract {
   }
   /**
   * Add a new admin. Careful who you add!
+  * @allow ["::admins", "::owner"]
   */
   add_adminTx(args: {
     account_id: AccountId;
@@ -543,6 +552,7 @@ export class Contract {
   /**
   * Update public sale price.
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   async update_price(args: {
     price: U128;
@@ -552,6 +562,7 @@ export class Contract {
   /**
   * Update public sale price.
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_priceRaw(args: {
     price: U128;
@@ -561,6 +572,7 @@ export class Contract {
   /**
   * Update public sale price.
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_priceTx(args: {
     price: U128;
@@ -570,6 +582,7 @@ export class Contract {
   /**
   * Update the presale price
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   async update_presale_price(args: {
     presale_price?: U128;
@@ -579,6 +592,7 @@ export class Contract {
   /**
   * Update the presale price
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_presale_priceRaw(args: {
     presale_price?: U128;
@@ -588,11 +602,24 @@ export class Contract {
   /**
   * Update the presale price
   * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+  * @allow ["::admins", "::owner"]
   */
   update_presale_priceTx(args: {
     presale_price?: U128;
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("update_presale_price", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
+  }
+  /**
+  * Current contract owner
+  */
+  owner(args = {}, options?: ViewFunctionOptions): Promise<AccountId> {
+    return this.account.viewFunction(this.contractId, "owner", args, options);
+  }
+  /**
+  * Current set of admins
+  */
+  admins(args = {}, options?: ViewFunctionOptions): Promise<AccountId[]> {
+    return this.account.viewFunction(this.contractId, "admins", args, options);
   }
   /**
   * Check whether an account is allowed to mint during the presale
@@ -675,12 +702,6 @@ export class Contract {
   */
   initial(args = {}, options?: ViewFunctionOptions): Promise<u64> {
     return this.account.viewFunction(this.contractId, "initial", args, options);
-  }
-  /**
-  * Current set of admins
-  */
-  admins(args = {}, options?: ViewFunctionOptions): Promise<AccountId[]> {
-    return this.account.viewFunction(this.contractId, "admins", args, options);
   }
   async new_default_meta(args: {
     owner_id: AccountId;
@@ -775,33 +796,6 @@ export class Contract {
   }, options?: ChangeMethodOptions): transactions.Action {
     return transactions.functionCall("nft_mint_many", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
   }
-  async on_send_with_callback(args = {}, options?: ChangeMethodOptions): Promise<void> {
-    return providers.getTransactionLastResult(await this.on_send_with_callbackRaw(args, options));
-  }
-  on_send_with_callbackRaw(args = {}, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "on_send_with_callback", args, ...options});
-  }
-  on_send_with_callbackTx(args = {}, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("on_send_with_callback", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
-  async link_callback(args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<Token> {
-    return providers.getTransactionLastResult(await this.link_callbackRaw(args, options));
-  }
-  link_callbackRaw(args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): Promise<providers.FinalExecutionOutcome> {
-    return this.account.functionCall({contractId: this.contractId, methodName: "link_callback", args, ...options});
-  }
-  link_callbackTx(args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  }, options?: ChangeMethodOptions): transactions.Action {
-    return transactions.functionCall("link_callback", args, options?.gas ?? DEFAULT_FUNCTION_CALL_GAS, options?.attachedDeposit ?? new BN(0))
-  }
 }
 /**
 * Create a pending token that can be claimed with corresponding private key
@@ -827,55 +821,6 @@ export interface CreateLinkdrop {
 }
 export type CreateLinkdrop__Result = void;
 /**
-* Allows given public key to claim sent balance.
-* Takes ACCESS_KEY_ALLOWANCE as fee from deposit to cover account creation via an access key.
-* Claim tokens for specific account that are attached to the public key this tx is signed with.
-* 
-* @contractMethod change
-*/
-export interface Claim {
-  args: {
-    account_id: AccountId;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type Claim__Result = void;
-/**
-* Create new account and and claim tokens to it.
-* 
-* @contractMethod change
-*/
-export interface CreateAccountAndClaim {
-  args: {
-    new_account_id: AccountId;
-    new_public_key: PublicKey;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type CreateAccountAndClaim__Result = void;
-/**
 * Returns the balance associated with given key.
 * 
 * @contractMethod view
@@ -898,28 +843,6 @@ export interface CheckKey {
 export type CheckKey__Result = boolean;
 /**
 * 
-* @contractMethod change
-*/
-export interface OnCreateAndClaim {
-  args: {
-    mint_for_free: boolean;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type OnCreateAndClaim__Result = void;
-/**
-* 
 * @contractMethod view
 */
 export interface GetLinkdropContract {
@@ -928,6 +851,7 @@ export interface GetLinkdropContract {
 }
 export type GetLinkdropContract__Result = AccountId;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -950,6 +874,7 @@ export interface TransferOwnership {
 }
 export type TransferOwnership__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -972,6 +897,7 @@ export interface UpdateInitialRoyalties {
 }
 export type UpdateInitialRoyalties__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -994,6 +920,7 @@ export interface UpdateRoyalties {
 }
 export type UpdateRoyalties__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1016,6 +943,7 @@ export interface UpdateAllowance {
 }
 export type UpdateAllowance__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1038,6 +966,7 @@ export interface UpdateUri {
 }
 export type UpdateUri__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1061,6 +990,7 @@ export interface AddWhitelistAccounts {
 }
 export type AddWhitelistAccounts__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1084,11 +1014,12 @@ export interface UpdateWhitelistAccounts {
 }
 export type UpdateWhitelistAccounts__Result = boolean;
 /**
-* Contract wwill
+* End public sale/minting, going back to the pre-presale state in which no one can mint.
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
-export interface CloseContract {
+export interface CloseSale {
   args: {};
   options: {
     /** Units in gas
@@ -1103,13 +1034,14 @@ export interface CloseContract {
   }
   
 }
-export type CloseContract__Result = boolean;
+export type CloseSale__Result = boolean;
 /**
 * Override the current presale start time to start presale now.
 * Most provide when public sale starts. None, means never.
 * Can provide new presale price.
 * Note: you most likely won't need to call this since the presale
 * starts automatically based on time.
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1133,6 +1065,7 @@ export interface StartPresale {
 }
 export type StartPresale__Result = boolean;
 /**
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1156,6 +1089,7 @@ export interface StartSale {
 export type StartSale__Result = boolean;
 /**
 * Add a new admin. Careful who you add!
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1180,6 +1114,7 @@ export type AddAdmin__Result = boolean;
 /**
 * Update public sale price.
 * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1204,6 +1139,7 @@ export type UpdatePrice__Result = boolean;
 /**
 * Update the presale price
 * Careful this is in yoctoNear: 1N = 1000000000000000000000000 yN
+* @allow ["::admins", "::owner"]
 * 
 * @contractMethod change
 */
@@ -1225,6 +1161,26 @@ export interface UpdatePresalePrice {
   
 }
 export type UpdatePresalePrice__Result = boolean;
+/**
+* Current contract owner
+* 
+* @contractMethod view
+*/
+export interface Owner {
+  args: {};
+  
+}
+export type Owner__Result = AccountId;
+/**
+* Current set of admins
+* 
+* @contractMethod view
+*/
+export interface Admins {
+  args: {};
+  
+}
+export type Admins__Result = AccountId[];
 /**
 * Check whether an account is allowed to mint during the presale
 * 
@@ -1358,16 +1314,6 @@ export interface Initial {
 }
 export type Initial__Result = u64;
 /**
-* Current set of admins
-* 
-* @contractMethod view
-*/
-export interface Admins {
-  args: {};
-  
-}
-export type Admins__Result = AccountId[];
-/**
 * 
 * @contractMethod change
 */
@@ -1483,46 +1429,3 @@ export interface NftMintMany {
   
 }
 export type NftMintMany__Result = Token[];
-/**
-* 
-* @contractMethod change
-*/
-export interface OnSendWithCallback {
-  args: {};
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type OnSendWithCallback__Result = void;
-/**
-* 
-* @contractMethod change
-*/
-export interface LinkCallback {
-  args: {
-    account_id: AccountId;
-    mint_for_free: boolean;
-  };
-  options: {
-    /** Units in gas
-    * @pattern [0-9]+
-    * @default "30000000000000"
-    */
-    gas?: string;
-    /** Units in yoctoNear
-    * @default "0"
-    */
-    attachedDeposit?: Balance;
-  }
-  
-}
-export type LinkCallback__Result = Token;


### PR DESCRIPTION
The idea of the comments in the Rust is that they will eventually be
generated by a Rust macro that replaces all the `assert_owner` calls.
The macro can look like:

    #[only(::owner, willem.near, ::admins, ::get_admin_contract_id::admins)]

Or maybe:

    #[only(owner, "willem.near", admins, ::get_admin_contract_id::admins)]

The "owner" view method could be auto-generated from a `derive` on the
struct:

    #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault, Ownable)]

While `::admins` and `::get_admin_contract_id` would be
explicitly-defined methods on this contract.

The methods specified here would all be expected to return `AccountId |
Vec<AccountId>`

::get_admin_contract_id::admins specifies that any accounts returned by
this method on an external contract should be allowed calling the
specified method. This would be simple to handle on a frontend, but
implies that a cross-contract call with callback is generated by having
such a specification in the macro.