### PR TITLE
build(gui): cache yarn dependencies

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -25,9 +25,9 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: '16.x'
+        cache: 'yarn'
     - name: Install and Build
       run: |
-        yarn cache clean
         yarn install --frozen-lockfile
         yarn gui:build
     - name: Deploy 🚀


### PR DESCRIPTION
From https://github.com/actions/setup-node#caching-packages-dependencies:

> The action has a built-in functionality for caching and restoring dependencies. It uses [actions/cache](https://github.com/actions/cache) under the hood for caching dependencies but requires less configuration settings. Supported package managers are `npm`, `yarn`, `pnpm` (v6.10+). The `cache` input is optional, and **caching is turned off by default**.

Not sure why all our [builds have been failing](https://github.com/TENK-DAO/tenk/runs/6012306525?check_suite_focus=true) while trying to access `/home/runner/.cache/yarn/v6`, if this is true.

Also not sure why explicitly turning ON the caching seems to fix it!