### PR TITLE
feat(gui): remove assumptions about admins methods

### DIFF
--- a/gui/src/near/methods.ts
+++ b/gui/src/near/methods.ts
@@ -1,4 +1,5 @@
 import topLevelSchema from "./contracts/tenk/index.schema.json";
+import { init } from '.'
 import { JSONSchema7 } from "json-schema";
 
 export type MethodName = keyof typeof topLevelSchema.definitions
@@ -20,21 +21,62 @@ function hasContractMethod(m: MethodName, equalTo?: "change" | "view"): boolean 
   return def.contractMethod === equalTo
 }
 
-function allowsAdmin(m: MethodName): boolean {
-  const def = topLevelSchema.definitions[m]
+/**
+ * Check if a given contract method can be called by an account.
+ * 
+ * Assumes the method has an `allow` field specifying accounts and methods in
+ * the following format:
+ * 
+ *     allow: [
+ *       'ahalabs.near',
+ *       '::owner',
+ *       '::admins',
+ *       '::dao.ahalabs.near::council'
+ *     ]
+ * 
+ * Someday there will be an SDK macro that makes adding this easy. For now,
+ * contracts can include comments above the method in the proper format, and
+ * witme will generate the schema with the above `allow` structure. Here's the
+ * proper comment format for a Rust contract:
+ * 
+ *     /// @allow ["::admins", "::owner"]
+ *     pub fn some_method(&mut self, ...)
+ * 
+ * @param contract string Name of contract to check permissions for
+ * @param method string Method of contract to check permissions for
+ * @param account string Account name that may or may not be allowed to call `method` on `contract`
+ * @returns boolean true of `account` can call `method` on `contract`, false if not
+ */
+export async function allows(contract: string, method: MethodName, account: string): Promise<boolean> {
+  const def = topLevelSchema.definitions[method]
   const hasField = hasAllowProperty(def)
-  if (!hasField) return false
-  return def.allow.includes('::admins')
+
+  // if no `allows` field, then anyone can call this method; return true
+  if (!hasField) return true
+
+  return (await Promise.all(def.allow.map(async accountOrMethod => {
+    // if `allow` value doesn't start with `::`, then it's a literal account name
+    if (accountOrMethod.slice(0, 2) !== '::') {
+      return accountOrMethod === account
+    }
+    // if only has a `::` at beginning, is the name of a method in `contract`
+    if (accountOrMethod.split('::').length === 2) {
+      const { near } = init(contract)
+      const [, method] = accountOrMethod.split('::')
+      const accountObj = await near.account(contract);
+      const accounts = Array.from(await accountObj.viewFunction(contract, method))
+      return accounts.includes(account)
+    }
+    const [, contractName, method] = accountOrMethod.split('::')
+    const { near } = init(contract)
+    const accountObj = await near.account(contractName);
+    const accounts = Array.from(await accountObj.viewFunction(contract, method))
+    return accounts.includes(account)
+  }))).reduce((acc, inGroup) => acc || inGroup, false)
 }
 
-export const adminMethods = Object.keys(topLevelSchema.definitions).filter(m =>
-  allowsAdmin(m as MethodName)
-) as MethodName[]
-
 export const changeMethods = Object.keys(topLevelSchema.definitions).filter(m =>
-  hasContractMethod(m as MethodName, "change") &&
-    !adminMethods.includes(m as MethodName) &&
-    !['New', 'NewDefaultMeta'].includes(m)
+  hasContractMethod(m as MethodName, "change")
 ) as MethodName[]
 
 export const viewMethods = Object.keys(topLevelSchema.definitions).filter(m =>


### PR DESCRIPTION
This removes entanglement between what will soon become a
general-purpose frontend and the admins behavior of the TenK contract.
Instead, it only assumes that a specific comment format is followed in
the contract. In the future these comments will be generated in the wit
if an admins macro is present for the given contract method.

Now `Change Methods` in the UI will be longer or shorter, depending on
which methods the signed-in user is able to call.

<img alt="demo" src="https://user-images.githubusercontent.com/221614/164469288-206261cf-da43-4f07-90b5-ba147c330500.gif" width="450px" />
