### PR TITLE
fix: allow dev-deploy contracts

### DIFF
--- a/gui/src/near/index.ts
+++ b/gui/src/near/index.ts
@@ -58,7 +58,7 @@ export function init(contract: string): ContractInterface {
 
   const config = /near$/.test(contract)
     ? mainnetConfig
-    : /testnet$/.test(contract)
+    : /testnet$/.test(contract) || /dev-[0-9]+-[0-9]+/.test(contract)
     ? testnetConfig
     : undefined
 


### PR DESCRIPTION
Use `testnet` config for contracts deployed with `near dev-deploy`