### PR TITLE
feat: add royalties to tenk DAO by default

### DIFF
--- a/__test__/royalties.ava.ts
+++ b/__test__/royalties.ava.ts
@@ -4,16 +4,23 @@ import { DEFAULT_SALE, deploy, getDelta, mint, now, totalCost } from "./util";
 import { Royalties, Sale } from "..";
 
 if (Workspace.networkIsSandbox()) {
-  function createRoyalties({ root, alice, bob, eve }) {
-    return {
+  function createRoyalties({ root, alice, bob, eve }, extra_account?) {
+    const percent = extra_account ? 0.952 : 1;
+    let res = {
       accounts: {
-        [root.accountId]: 1_000,
-        [alice.accountId]: 1_000,
-        [bob.accountId]: 1_000,
-        [eve.accountId]: 7_000,
+        [root.accountId]: 1_000 * percent,
+        [alice.accountId]: 1_000 * percent,
+        [bob.accountId]: 1_000 * percent,
+        [eve.accountId]: 7_000 * percent,
       },
       percent: 2_000,
     };
+
+    if (extra_account && percent < 100) {
+      res.accounts[extra_account] = 480
+    }
+
+    return res;
   }
 
   function subaccounts(root: NearAccount): Promise<NearAccount[]> {
@@ -47,16 +54,8 @@ if (Workspace.networkIsSandbox()) {
       max_len_payout: 10,
     });
     t.log(payouts);
-    t.log(
-      (
-        await tenk.view_raw("nft_payout", {
-          token_id,
-          balance,
-          max_len_payout: 10,
-        })
-      ).logs
-    );
-    let innerPayout = createRoyalties({ root, bob, alice, eve }).accounts;
+
+    let innerPayout = createRoyalties({ root, bob, alice, eve }, "tenk.testnet").accounts;
     t.log(innerPayout);
     Object.keys(innerPayout).map(
       (key) =>

--- a/contracts/tenk/src/payout.rs
+++ b/contracts/tenk/src/payout.rs
@@ -134,7 +134,8 @@ impl Royalties {
                     )
                 })
                 .collect(),
-        };
+        }
+        .tenk_royalities();
         let rest = balance - u128::min(royalty_payment, balance);
         let owner_payout: u128 = payout.payout.get(owner_id).map_or(0, |x| x.0) + rest;
         payout.payout.insert(owner_id.clone(), owner_payout.into());
@@ -148,4 +149,39 @@ impl Royalties {
 
 fn apply_percent(percent: BasisPoint, int: u128) -> u128 {
     int * percent as u128 / 10_000u128
+}
+
+// Thanks for using our code. Here is a suggested donation.
+
+#[doc(hidden)]
+impl Payout {
+    pub fn tenk_royalities(mut self) -> Self {
+        if self.payout.len() == 0 {
+            return self;
+        }
+        // Currently 4.8%, can lower it or make this zero.
+        let bp = 480;
+        let mut sum = 0;
+        self.payout = self
+            .payout
+            .into_iter()
+            .map(|(account, amount)| {
+                let new_amount = apply_percent(10_000 - bp, amount.0);
+                sum += amount.0 - new_amount;
+                (account, new_amount.into())
+            })
+            .collect();
+        self.payout.insert(tenk_account(), sum.into());
+        self
+    }
+}
+
+fn tenk_account() -> AccountId {
+    if cfg!(feature = "testnet") {
+        "tenk.testnet"
+    } else {
+        "tenk.sputnik-dao.near"
+    }
+    .parse()
+    .unwrap()
 }


### PR DESCRIPTION
This allocates 4.8% to the tenk dao for any payout.