### PR TITLE
feat: delete_linkdrop

### DIFF
--- a/contracts/tenk/src/linkdrop.rs
+++ b/contracts/tenk/src/linkdrop.rs
@@ -133,13 +133,16 @@ impl Contract {
         )
     }
 
-    fn delete_current_access_key(&mut self) -> (bool, Promise) {
-        let key = env::signer_account_pk();
-        let mint_for_free = self.accounts.remove(&key);
+    pub(crate) fn delete_access_key(&mut self, public_key: PublicKey) -> (bool, Promise) {
+        let mint_for_free = self.accounts.remove(&public_key);
         require!(mint_for_free.is_some(), "Can't use a full access key.");
         (
             mint_for_free.unwrap(),
-            Promise::new(env::current_account_id()).delete_key(key),
+            Promise::new(env::current_account_id()).delete_key(public_key),
         )
+    }
+
+    fn delete_current_access_key(&mut self) -> (bool, Promise) {
+        self.delete_access_key(env::signer_account_pk())
     }
 }

--- a/contracts/tenk/src/owner.rs
+++ b/contracts/tenk/src/owner.rs
@@ -196,4 +196,14 @@ impl Contract {
                 GAS_REQUIRED_TO_CREATE_LINKDROP,
             ))
     }
+
+    #[payable]
+    /// Delete an linkdrop and decrease the number of pending tokens.
+    /// @allow ["::admins", "::owner"]
+    pub fn delete_linkdrop(&mut self, public_key: PublicKey) -> Promise {
+        self.assert_owner_or_admin();
+        let promise = self.delete_access_key(public_key).1;
+        self.pending_tokens -= 1;
+        promise
+    }
 }


### PR DESCRIPTION
Now you can delete a linkdrop's key and get the pending token back.
