### PR TITLE
feat: add `remove_whitelist_account` and fix update_allowance

### DIFF
--- a/contracts/tenk/src/owner.rs
+++ b/contracts/tenk/src/owner.rs
@@ -72,6 +72,14 @@ impl Contract {
         true
     }
 
+    /// Remove whitelisted account. If account is removed, the number of tokens left in returned.
+    /// @allow ["::admins", "::owner"]
+    pub fn remove_whitelist_account(&mut self, account_id: AccountId) -> Option<u16> {
+        self.assert_owner_or_admin();
+        self.whitelist.remove(&account_id).as_ref().map(Allowance::left)
+    }
+
+
     /// Increases allowance for whitelist accounts
     /// @allow ["::admins", "::owner"]
     pub fn update_whitelist_accounts(

--- a/contracts/tenk/src/owner.rs
+++ b/contracts/tenk/src/owner.rs
@@ -31,10 +31,13 @@ impl Contract {
         true
     }
 
+    /// This is the allowance during the public sale.
+    /// When an allowance isn't provided, it is unlimited.
+    /// e.g. submit with no `allowance` argument
     /// @allow ["::admins", "::owner"]
-    pub fn update_allowance(&mut self, allowance: u16) -> bool {
+    pub fn update_allowance(&mut self, allowance: Option<u16>) -> bool {
         self.assert_owner_or_admin();
-        self.sale.allowance = Some(allowance);
+        self.sale.allowance = allowance;
         true
     }
 


### PR DESCRIPTION
This PR fixes issues with allowance not updating correctly during the public sale.

It also adds a new method `remove_whitelist_account` which has been requested multiple times.